### PR TITLE
Update for Rails 5

### DIFF
--- a/rails-reveal-js.gemspec
+++ b/rails-reveal-js.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "railties", "~> 4.0"
+  spec.add_dependency "railties", ">= 4.0"
 end


### PR DESCRIPTION
rails-reveal-js works fine with no changes to Rails5, with the exception that the gemspec needs to be on 5.0 for railties.

Feel free to go a different way with this, but this works without trouble for me.

For others needing a solution right now, you can do this in your Gemfile:

```
gem 'rails-reveal-js', github: 'jwo/rails-reveal-js'
```
